### PR TITLE
Mudando sac-am

### DIFF
--- a/src/sac-dm/sacdm.py
+++ b/src/sac-dm/sacdm.py
@@ -198,9 +198,9 @@ def plot_SAC_AM_DM_drone_signals():
 
 
 	# # 								Matriz de confusao
-	# util.confusionMatrix([sac_am_F0_x, sac_am_F6_x, sac_am_F14_x, sac_am_F22_x], ["F0", "F6", "F14", "F22"], "SAC-AM: Eixo X")
-	# util.confusionMatrix([sac_am_F0_y, sac_am_F6_y, sac_am_F14_y, sac_am_F22_y], ["F0", "F6", "F14", "F22"], "SAC-AM: Eixo Y")
-	# util.confusionMatrix([sac_am_F0_z, sac_am_F6_z, sac_am_F14_z, sac_am_F22_z], ["F0", "F6", "F14", "F22"], "SAC-AM: Eixo Z")
+	util.confusionMatrix([sac_am_F0_x, sac_am_F6_x, sac_am_F14_x, sac_am_F22_x], ["F0", "F6", "F14", "F22"], "SAC-AM: Eixo X")
+	util.confusionMatrix([sac_am_F0_y, sac_am_F6_y, sac_am_F14_y, sac_am_F22_y], ["F0", "F6", "F14", "F22"], "SAC-AM: Eixo Y")
+	util.confusionMatrix([sac_am_F0_z, sac_am_F6_z, sac_am_F14_z, sac_am_F22_z], ["F0", "F6", "F14", "F22"], "SAC-AM: Eixo Z")
 
 	# util.confusionMatrix([sac_dm_F0_x, sac_dm_F6_x, sac_dm_F14_x, sac_dm_F22_x], ["F0", "F6", "F14", "F22"], "SAC-DM: Eixo X")
 	# util.confusionMatrix([sac_dm_F0_y, sac_dm_F6_y, sac_dm_F14_y, sac_dm_F22_y], ["F0", "F6", "F14", "F22"], "SAC-DM: Eixo Y")
@@ -364,7 +364,7 @@ def plot_SAC_AM_DM_motor_signals():
 	# Plotando graficos de forma individual
 
 	# #								SAC-AM
-	util.showTreinamentoC([sac_am_C0_x, sac_am_C0_y, sac_am_C0_z], (f"SAC-AM: Arquivo C0 - N{N}"), "C0")
+	# util.showTreinamentoC([sac_am_C0_x, sac_am_C0_y, sac_am_C0_z], (f"SAC-AM: Arquivo C0 - N{N}"), "C0")
 	# util.showTreinamentoC([sac_am_C2_x, sac_am_C2_y, sac_am_C2_z], (f"SAC-AM: Arquivo C2 - N{N}"), "C2")
 	# util.showTreinamentoC([sac_am_C4_x, sac_am_C4_y, sac_am_C4_z], (f"SAC-AM: Arquivo C4 - N{N}"), "C4")
 	# util.showTreinamentoC([sac_am_C10_x, sac_am_C10_y, sac_am_C10_z], (f"SAC-AM: Arquivo C10 - N{N}"), "C10")
@@ -422,5 +422,5 @@ def plot_SAC_AM_DM_motor_signals():
 
 #********* Main ********
 
-# plot_SAC_AM_DM_drone_signals()
-plot_SAC_AM_DM_motor_signals()
+plot_SAC_AM_DM_drone_signals()
+# plot_SAC_AM_DM_motor_signals()

--- a/src/sac-dm/sacdm.py
+++ b/src/sac-dm/sacdm.py
@@ -51,9 +51,9 @@ def sac_am(data, N):
 	inicio = 0
 	fim = N
 	for k in range(size):
-		peaks, _ = find_peaks(data[inicio:fim])
-		v = np.abs(data[peaks])
-		s = np.mean(v)
+		# peaks, _ = find_peaks(data[inicio:fim])
+		# v = np.abs(data[peaks])
+		s = np.std(data[inicio:fim])
 		sacdm[k] = 1.0*s/N
 		inicio = fim
 		fim = fim + N
@@ -170,8 +170,8 @@ def plot_SAC_AM_DM_drone_signals():
 	# # Plotando na mesma figura 3 graficos( 1 para cada eixo ), contendo o treinamento e o teste feitos em arquivos diferentes
 	# #								SAC-AM: Treinamento com arquivo base completo e metade
 
-	# util.showSAC_figUnicaComTreinoC( ([[sac_am_F0_x, sac_am_F0_y, sac_am_F0_z], [sac_am_F6_x, sac_am_F6_y, sac_am_F6_z], [sac_am_F14_x, sac_am_F14_y, sac_am_F14_z],
-	#  								   [sac_am_F22_x, sac_am_F22_y, sac_am_F22_z]]), (f"SAC-AM: Treinamento Completo - N{N}"), ["F0","F6","F14","F22"])
+	util.showSAC_figUnicaComTreinoC( ([[sac_am_F0_x, sac_am_F0_y, sac_am_F0_z], [sac_am_F6_x, sac_am_F6_y, sac_am_F6_z], [sac_am_F14_x, sac_am_F14_y, sac_am_F14_z],
+	 								   [sac_am_F22_x, sac_am_F22_y, sac_am_F22_z]]), (f"SAC-AM: Treinamento Completo - N{N}"), ["F0","F6","F14","F22"])
 	
 	# util.showSAC_figUnicaComTreinoM( ([[sac_am_F0_x, sac_am_F0_y, sac_am_F0_z], [sac_am_F6_x, sac_am_F6_y, sac_am_F6_z], [sac_am_F14_x, sac_am_F14_y, sac_am_F14_z],
 	#  								   [sac_am_F22_x, sac_am_F22_y, sac_am_F22_z]]), (f"SAC-AM: Treinamento Metade - N{N}"), ["F0","F6","F14","F22"])

--- a/src/sac-dm/sacdm.py
+++ b/src/sac-dm/sacdm.py
@@ -53,7 +53,7 @@ def sac_am(data, N):
 	for k in range(size):
 		peaks, _ = find_peaks(data[inicio:fim])
 		v = np.abs(data[peaks])
-		s = sum(v)
+		s = np.mean(v)
 		sacdm[k] = 1.0*s/N
 		inicio = fim
 		fim = fim + N

--- a/src/sac-dm/util.py
+++ b/src/sac-dm/util.py
@@ -43,6 +43,9 @@ def treinamentoCompleto(dataset, title, fig, ax, file_tag):
 	media_dataset = media_sac(dataset, 0, round(len(dataset)))
 	desv_dataset = desvio_sac(dataset, 0, round(len(dataset)))
 
+	min_global = np.min(dataset)
+	max_global = np.max(dataset)
+
 	aux_desv = np.zeros(len(dataset))
 	aux_desv[round((len(dataset))/2)] = desv_dataset
 
@@ -60,7 +63,7 @@ def treinamentoCompleto(dataset, title, fig, ax, file_tag):
 		if(aux_desv[j] != 0):			
 			ax.errorbar(j,media_dataset,yerr = aux_desv[j], color = colors[20],marker='s', capsize=2, markersize=4, linewidth=1, linestyle='--')
 
-	ax.fill_between(x, media_dataset - desv_dataset, media_dataset + desv_dataset, alpha = 0.2, label = (f"Desvio Padrão do Arquivo {file_tag}"))
+	ax.fill_between(x, min_global, max_global, alpha = 0.2, label = (f"Desvio Padrão do Arquivo {file_tag}"))
 
 def testagem(dataset, title, fig, ax, color):
 
@@ -185,27 +188,34 @@ def confusionMatrix(dataset, arquivos, title):
 	media = np.zeros((len(dataset)))
 	desvio = np.zeros((len(dataset)))
 	matrix = np.zeros((len(dataset),len(dataset)+1))
+	min_global = np.zeros((len(dataset)))
+	max_global = np.zeros((len(dataset)))
 
 	for i in range(len(dataset)):
 		media[i] = media_sac(dataset[i], 0, len(dataset[i]))
 		desvio[i] = desvio_sac(dataset[i], 0, len(dataset[i]))
+		min_global[i] = np.min(dataset[i])
+		max_global[i] = np.max(dataset[i])
+
+	print(media)
+	print(desvio)
 
 	for i in range(len(dataset)): # Arquivos com os mesmos eixos
 		for j in range(len(dataset[i])): # array com n pontos
 			
-			if (dataset[i][j] >= media[0] - desvio[0] and dataset[i][j] <= media[0] + desvio[0]):
+			if (dataset[i][j] >= min_global[0] and dataset[i][j] <= max_global[0]):
 				matrix[i][0] += 1
 				continue
 
-			elif(dataset[i][j] >= media[1] - desvio[1] and dataset[i][j] <= media[1] + desvio[1]):
+			elif(dataset[i][j] >= min_global[1] and dataset[i][j] <= max_global[1]):
 				matrix[i][1] += 1
 				continue
 
-			elif(dataset[i][j] >= media[2] - desvio[2] and dataset[i][j] <= media[2] + desvio[2]):
+			elif(dataset[i][j] >= min_global[2] and dataset[i][j] <= max_global[2]):
 				matrix[i][2] += 1
 				continue
 
-			elif(dataset[i][j] >= media[3] - desvio[3] and dataset[i][j] <= media[3] + desvio[3]):
+			elif(dataset[i][j] >= min_global[3] and dataset[i][j] <= max_global[3]):
 				matrix[i][3] += 1
 				continue
 			


### PR DESCRIPTION
Retiramos superposições de sinais ao usar a média da densidade de máximos, implicando em uma maior diagonalização da matriz de confusão.